### PR TITLE
add deviceInterruptHandler (not done yet)

### DIFF
--- a/phase2/interrupts.c
+++ b/phase2/interrupts.c
@@ -1,7 +1,48 @@
 #include "include/interrupts.h"
 
 static void deviceInterruptHandler(int line, int cause, state_t *exceptionState) {
-		
+	devregarea_t *devicesRegisterArea = (devregarea_t *)BUS_REG_RAM_BASE;
+	unsigned int interruptingDevicesBitmap = devicesRegisterArea->interrupt_dev[line - 3];
+	unsigned int deviceStatus;
+  unsigned int deviceNumber;
+  	
+  //ordered by priority
+  if(interruptingDevicesBitmap & DEV0ON)
+    deviceNumber = 0;
+  else if(interruptingDevicesBitmap & DEV1ON)
+    deviceNumber = 1;
+  else if(interruptingDevicesBitmap & DEV2ON)
+    deviceNumber = 2;
+  else if(interruptingDevicesBitmap & DEV3ON)
+    deviceNumber = 3;
+  else if(interruptingDevicesBitmap & DEV4ON)
+    deviceNumber = 4;
+  else if(interruptingDevicesBitmap & DEV5ON)
+    deviceNumber = 5;
+  else if(interruptingDevicesBitmap & DEV6ON)
+    deviceNumber = 6;
+  else if(interruptingDevicesBitmap & DEV7ON)
+    deviceNumber = 7;
+
+  devreg_t *deviceRegister = DEV_REG_ADDR(line, deviceNumber); 
+
+  if(line == IL_TERMINAL){} //va gestito diversamente --> 2 sub-devices
+  else{
+    pcb_t* unblockedPCB;
+    deviceStatus = deviceRegister->status;
+    deviceRegister->command = ACK;
+    //unblock PCB --> come ottenerlo? Vedi punto 4 del capitolo 8.1 specifiche
+    if(unblockedPCB) {
+      unblockedPCB->p_s.s_v0 = deviceStatus;
+    }
+    if(currentProcess) {
+      LDST(exceptionState);
+    }
+    else {
+      //Scheduler farà WAIT()
+    }
+  }
+
 }
 static void localTimerInterruptHandler(state_t *exceptionState) {}
 static void pseudoClockInterruptHandler(state_t* exceptionState) {}
@@ -20,7 +61,43 @@ void interruptHandler(int cause, state_t *exceptionState) {
 		deviceInterruptHandler(IL_ETHERNET, cause, exceptionState);
 	else if (CAUSE_IP_GET(cause, IL_PRINTER))
 		deviceInterruptHandler(IL_PRINTER, cause, exceptionState);
-	else if (CAUSE_IP_GET(cause, IL_TERMINAL))
-		deviceInterruptHandler(IL_TERMINAL, cause, exceptionState);
-}
+	else if (CAUSE_IP_GET(cause, IL_TERMINAL)) 
+    deviceInterruptHandler(IL_TERMINAL, cause, exceptionState); 
+} 
+/*Device register type for disks, flash and printers 
+typedef struct dtpreg { 
+unsigned int status; 
+unsigned int command; 
+unsigned int data0;
+unsigned int data1;
+} dtpreg_t;
+ Device register type for terminals 
+typedef struct termreg {
+unsigned int recv_status;
+unsigned int recv_command;
+unsigned int transm_status;
+unsigned int transm_command;
+} termreg_t;
+typedef union devreg {
+dtpreg_t dtp;
+termreg_t term;
+} devreg_t;
+ Bus register area 
+typedef struct devregarea {
+unsigned int rambase;
+unsigned int ramsize;
+unsigned int execbase;
+unsigned int execsize;
+unsigned int bootbase;
+unsigned int bootsize;
+unsigned int todhi;
+unsigned int todlo;
+unsigned int intervaltimer;
+unsigned int timescale;
+unsigned int TLBFloorAddr;
+unsigned int inst_dev[5];
+unsigned int interrupt_dev[5];
+devreg_t devreg[5][8];
+} devregarea_t;
+*/
 


### PR DESCRIPTION
Ho più o meno realizzato la funzione per la gestione degli interrupt dei dispositivi, devo gestire il caso del dispositivo del terminale (perché 1 terminale è un doppio dispositivo (in e out)), ciò che ho fatto è la realizzazione del punto 8.1 delle specifiche. Per farlo ho usato alcune variabili globali non ancora definite (le dovrà fare @aNdReA9111 ), solo per dare una struttura al codice poi eventualmente cambierò i nomi. Alcune cose sono commentate sempre perché non ho ancora tutte le variabili e la strutture dati che mi servono. Dateci un'occhiata e ditemi.