### PR TITLE
add pass up or die and uTLB_RefillHandler, fix includes, fix exceptionHandler code

### DIFF
--- a/phase2/exceptions.c
+++ b/phase2/exceptions.c
@@ -1,5 +1,22 @@
 #include "include/exceptions.h"
 
+static void passUpOrDie(int i, state_t *exceptionState) {
+  if(Current_Process) {
+    if(Current_Process->p_supportStruct) {
+      Current_Process->p_supportStruct->sup_exceptState[i] = *exceptionState;
+      LDCXT(
+        Current_Process->p_supportStruct->sup_exceptContext[i].c_stackPtr,
+        Current_Process->p_supportStruct->sup_exceptContext[i].c_status,
+        Current_Process->p_supportStruct->sup_exceptContext[i].c_pc,
+      );
+    }
+    else {
+      //terminate process 
+      //scheduler();
+    }
+  }
+}
+
 void exceptionHandler() {
 	state_t *exceptionState = (state_t *)BIOSDATAPAGE;
 	int cause = getCAUSE();
@@ -10,14 +27,24 @@ void exceptionHandler() {
 			break;
 		case 1 ... 3:
 			//TLB exceptions --> passo controllo al rispettivo gestore
+      passUpOrDie(PGFAULTEXCEPT, exceptionState);
 			break;
 		case SYSEXCEPTION:
-			//
+			//anche qui potrebbe sevire passUpOrDie ma la situa vs gestita
+      //diversamente
 			break;
 		default: //4-7, 9-12
 			//Program traps --> passo controllo al rispettivo gestore
+      passUpOrDie(GENERALEXCEPT, exceptionState);
 			break;
  }
+}
+
+void uTLB_RefillHandler() {
+  setENTRYHI(0x80000000);
+  setENTRYLO(0x00000000);
+  TLBWR();
+  LDST((state_t*) 0x0FFFF000);
 }
 
 

--- a/phase2/include/exceptions.h
+++ b/phase2/include/exceptions.h
@@ -2,10 +2,12 @@
 #define EXCEPTIONS
 #include "../../headers/const.h"
 #include "../../headers/types.h"
-#include "include/interrupts.h"
+#include "interrupts.h"
+#include "initial.h"
 #include <umps/libumps.h>
 #include <umps/arch.h>
 
 extern void exceptionHandler();
+extern void uTLB_RefillHandler();
 
 #endif

--- a/phase2/include/interrupts.h
+++ b/phase2/include/interrupts.h
@@ -2,6 +2,7 @@
 #define INTERRUPTS
 #include "../../headers/const.h"
 #include "../../headers/types.h"
+#include "initial.h" //not defined yet
 #include <umps/libumps.h>
 #include <umps/arch.h>
 

--- a/phase2/interrupts.c
+++ b/phase2/interrupts.c
@@ -59,7 +59,7 @@ static void deviceInterruptHandler(int line, int cause, state_t *exceptionState)
 }
 static void localTimerInterruptHandler(state_t *exceptionState) {
   setTIMER(TIMESLICE);
-  currentProcess->p_s = exceptionState;
+  currentProcess->p_s = *exceptionState;
   //mettere currentProcess nella ready queue --> funzione da definire
   //scheduler(); --> non ancora definito
 }


### PR DESCRIPTION
@aNdReA9111 ho notato che nel  tuo file initial.c usi la keyword "export" che in C non credo esista, inoltre secondo me conviene che tu crei le variabili globali in un file .h (initial.h) per tenere le cose più in ordine, poi vedi tu. Il pass up or die dovrebbe essere giusto, devo capire come usarlo con le system calls.