### PR TITLE
Devices semaphores

### DIFF
--- a/phase3/include/initProc.h
+++ b/phase3/include/initProc.h
@@ -15,6 +15,10 @@
 #include <umps/arch.h>
 #include <umps/cp0.h>
 
+#define TERM0ADDR 0x10000254
+#define PRINTCHR 2 
+#define TERMSTATMASK 0xFF
+#define RECVD 5
 
 extern support_t ss_array[UPROCMAX]; //support struct array
 extern state_t UProc_state[UPROCMAX];

--- a/phase3/include/initProc.h
+++ b/phase3/include/initProc.h
@@ -16,6 +16,7 @@
 #include <umps/cp0.h>
 
 #define TERM0ADDR 0x10000254
+#define PRINTER0ADDR 0x
 #define PRINTCHR 2 
 #define TERMSTATMASK 0xFF
 #define RECVD 5
@@ -25,7 +26,6 @@ extern state_t UProc_state[UPROCMAX];
 extern pcb_t *swap_mutex_pcb;
 extern swap_t swap_pool_table[POOLSIZE];
 extern pcb_t *sst_array[UPROCMAX];
-//extern pcb_t *terminal_pcbs_recv[UPROCMAX];
 extern pcb_t *terminal_pcbs[UPROCMAX];
 extern pcb_t *printer_pcbs[UPROCMAX];
 

--- a/phase3/include/initProc.h
+++ b/phase3/include/initProc.h
@@ -16,10 +16,12 @@
 #include <umps/cp0.h>
 
 #define TERM0ADDR 0x10000254
-#define PRINTER0ADDR 0x
+#define TERMSTATMASK 0xFF
+#define PRINTER0ADDR 0x100001D4
 #define PRINTCHR 2 
 #define TERMSTATMASK 0xFF
 #define RECVD 5
+#define READY 1
 
 extern support_t ss_array[UPROCMAX]; //support struct array
 extern state_t UProc_state[UPROCMAX];

--- a/phase3/initProc.c
+++ b/phase3/initProc.c
@@ -5,7 +5,6 @@ state_t UProc_state[UPROCMAX];
 pcb_t *swap_mutex_pcb;
 swap_t swap_pool_table[POOLSIZE];
 pcb_t *sst_array[UPROCMAX];
-//pcb_t *terminal_pcbs_recv[UPROCMAX];
 pcb_t *terminal_pcbs[UPROCMAX];
 pcb_t *printer_pcbs[UPROCMAX];
 
@@ -95,7 +94,8 @@ static void initSwapMutex()
     create_process(&swap_mutex_state, NULL);
 }
 
-
+//funzione che riceve una stringa e la stampa sul device specificato 
+//dai 2 parametri
 void print(int device_number, unsigned int *base_address)
 {
     while (1)
@@ -131,6 +131,9 @@ void print(int device_number, unsigned int *base_address)
     }
 }
 
+//wrapper della funzione per poterla assegnare ai 
+//program counter dei processi semafori
+
 void print_term0 { print(0, (unsigned int *)TERM0ADDR); }
 void print_term1 { print(1, (unsigned int *)TERM0ADDR); }
 void print_term2 { print(2, (unsigned int *)TERM0ADDR); }
@@ -149,6 +152,8 @@ void printer5 { print(5, (unsigned int *)PRINTER0ADDR); }
 void printer6 { print(6, (unsigned int *)PRINTER0ADDR); }
 void printer7 { print(7, (unsigned int *)PRINTER0ADDR); }
 
+//array di puntatori ai wrapper soprastanti per 
+//una maggiore comodità durante l'assegnamento al program counter
 
 void (*terminals[8]) () = {print_term0, print_term1, print_term2, print_term3, print_term4, print_term5, print_term6, print_term7};
 void (*printers[8]) () = {printer0, printer1, printer2, printer3, printer4, printer5, printer6, printer7};

--- a/phase3/initProc.c
+++ b/phase3/initProc.c
@@ -105,11 +105,15 @@ void print(int device_number, unsigned int *base_address)
         char *s = msg;
         unsigned int *base0 = base_addres; //indirizzo base termiale 0 o stampante 0
         //basen =base0 + 4 * n
-        unsigned int *command = base0 + 4 * device_number + 3;
+        if(base_address == TERM0ADDR)
+            unsigned int *command = base0 + 4 * device_number + 3;
+        else
+            
+            unsigned int *command = base0 + 4 * device_number + 3;
         unsigned int status;
         
         while (*s != EOS)
-        {
+        {   /////////////////////
             unsigned int value = PRINTCHR | (((unsigned int)*s) << 8);
             ssi_do_io_t do_io = {
                 .commandAddr = command,
@@ -122,7 +126,9 @@ void print(int device_number, unsigned int *base_address)
             SYSCALL(SENDMESSAGE, (unsigned int)ssi_pcb, (unsigned int)(&payload), 0);
             SYSCALL(RECEIVEMESSAGE, (unsigned int)ssi_pcb, (unsigned int)(&status), 0);
             
-            if ((status & TERMSTATMASK) != RECVD)
+            if (base_addres == TERM0ADDR && (status & TERMSTATMASK) != RECVD)
+                PANIC();
+            if (base_address == PRINTER0ADDR && status != READY)
                 PANIC();
             s++;
         }

--- a/phase3/initProc.c
+++ b/phase3/initProc.c
@@ -103,18 +103,26 @@ void print(int device_number, unsigned int *base_address)
         char *msg;
         unsigned int sender = SYSCALL(RECEIVEMESSAGE, ANYMESSAGE, (unsigned int)(&msg), 0);
         char *s = msg;
-        unsigned int *base0 = base_addres; //indirizzo base termiale 0 o stampante 0
+        unsigned int *base = base_address + 4 * device_number; //indirizzo base
         //basen =base0 + 4 * n
+        unsigned int *command;
         if(base_address == TERM0ADDR)
-            unsigned int *command = base0 + 4 * device_number + 3;
+            command = base + 3;
         else
-            
-            unsigned int *command = base0 + 4 * device_number + 3;
+            command = base + 1;
+        unsigned int *data0 = base + 2; //usato solo con stampanti
         unsigned int status;
         
         while (*s != EOS)
-        {   /////////////////////
-            unsigned int value = PRINTCHR | (((unsigned int)*s) << 8);
+        {    
+            unsigned int value;
+            if(base_address == TERM0ADDR)
+                value = PRINTCHR | (((unsigned int)*s) << 8);
+            else {
+                value = PRINTCHR; //con le stampanti il valore va nel registro DATA0, non in command
+                *data0 = (unsigned int)*s;
+            }
+
             ssi_do_io_t do_io = {
                 .commandAddr = command,
                 .commandValue = value,

--- a/phase3/initProc.c
+++ b/phase3/initProc.c
@@ -95,6 +95,64 @@ static void initSwapMutex()
     create_process(&swap_mutex_state, NULL);
 }
 
+
+void print(int device_number, unsigned int *base_address)
+{
+    while (1)
+    {
+        char *msg;
+        unsigned int sender = SYSCALL(RECEIVEMESSAGE, ANYMESSAGE, (unsigned int)(&msg), 0);
+        char *s = msg;
+        unsigned int *base0 = base_addres; //indirizzo base termiale 0 o stampante 0
+        //basen =base0 + 4 * n
+        unsigned int *command = base0 + 4 * device_number + 3;
+        unsigned int status;
+        
+        while (*s != EOS)
+        {
+            unsigned int value = PRINTCHR | (((unsigned int)*s) << 8);
+            ssi_do_io_t do_io = {
+                .commandAddr = command,
+                .commandValue = value,
+            };
+            ssi_payload_t payload = {
+                .service_code = DOIO,
+                .arg = &do_io,
+            };
+            SYSCALL(SENDMESSAGE, (unsigned int)ssi_pcb, (unsigned int)(&payload), 0);
+            SYSCALL(RECEIVEMESSAGE, (unsigned int)ssi_pcb, (unsigned int)(&status), 0);
+            
+            if ((status & TERMSTATMASK) != RECVD)
+                PANIC();
+            s++;
+        }
+        
+        SYSCALL(SENDMESSAGE, (unsigned int)sender, 0, 0);
+    }
+}
+
+void print_term0 { print(0, (unsigned int *)TERM0ADDR); }
+void print_term1 { print(1, (unsigned int *)TERM0ADDR); }
+void print_term2 { print(2, (unsigned int *)TERM0ADDR); }
+void print_term3 { print(3, (unsigned int *)TERM0ADDR); }
+void print_term4 { print(4, (unsigned int *)TERM0ADDR); }
+void print_term5 { print(5, (unsigned int *)TERM0ADDR); }
+void print_term6 { print(6, (unsigned int *)TERM0ADDR); }
+void print_term7 { print(7, (unsigned int *)TERM0ADDR); }
+
+void printer0 { print(0, (unsigned int *)PRINTER0ADDR); }
+void printer1 { print(1, (unsigned int *)PRINTER0ADDR); }
+void printer2 { print(2, (unsigned int *)PRINTER0ADDR); }
+void printer3 { print(3, (unsigned int *)PRINTER0ADDR); }
+void printer4 { print(4, (unsigned int *)PRINTER0ADDR); }
+void printer5 { print(5, (unsigned int *)PRINTER0ADDR); }
+void printer6 { print(6, (unsigned int *)PRINTER0ADDR); }
+void printer7 { print(7, (unsigned int *)PRINTER0ADDR); }
+
+
+void (*terminals[8]) () = {print_term0, print_term1, print_term2, print_term3, print_term4, print_term5, print_term6, print_term7};
+void (*printers[8]) () = {printer0, printer1, printer2, printer3, printer4, printer5, printer6, printer7};
+
 static void initSemProc()
 {
     //creazione e inizializzazione dei processi che si comportano come semafori dei 
@@ -104,7 +162,12 @@ static void initSemProc()
 
         state_t p_state;
         p_state.reg_sp = (memaddr)curr;
-        p_state.pc_epc = ...; //da definire
+        
+        if(i < 8)
+            p_state.pc_epc = terminals[i]; 
+        else
+            p_state.pc_epc = printers[i - 8]; 
+        
         p_state.status = ALLOFF | IEPON | IMON | TEBITON;
         
         if(i < 8)
@@ -120,7 +183,7 @@ void test()
     pcb_t *test = current_process;
     initSwapPoolTable();    //Swap Pool init
     initUProc();            //init U-procs
-    initSST();              //init and create SSTs 
     initSwapMutex();        //init and create swap mutex process
     initSemProc();          //init and create devices semaphore processes
+    initSST();              //init and create SSTs 
 }

--- a/phase3/sysSupport.c
+++ b/phase3/sysSupport.c
@@ -31,7 +31,7 @@ void generalExceptionHandler(){
   };
   SYSCALL(SENDMESSAGE, (unsigned int)ssi_pcb, (unsigned int)(&getsup_payload), 0);
   SYSCALL(RECEIVEMESSAGE, (unsigned int)ssi_pcb, (unsigned int)(&sup_struct_ptr), 0);
-	state_t *exception_state = &sup_struct_ptr->sup_exceptState[GENERALEXCEPT];  
+	state_t exception_state = sup_struct_ptr->sup_exceptState[GENERALEXCEPT];  
 	int cause = exception_state.cause;
 
   switch((cause & GETEXECCODE) >> CAUSESHIFT){


### PR DESCRIPTION
Aggiunti processi che fanno da semafori ai dispositivi, codice già commentato. @LucaSlv3 ora nella tua parte quando fai la writeprint e la writeterm, non devi più fare il ciclo di chiamate DOIO perché ci pensano questi processi. Dovrai modificare il tuo codice affinché l'SST mandi la stringa da stampare al rispettivo processo (es. SST5 manderà messaggi solo al processo printer5 o print_term5), c'è un array di questi processi da cui puoi accedere facilemente con l'indice (asid - 1).